### PR TITLE
Remove usage of closure in config file

### DIFF
--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -86,11 +86,6 @@ return array(
 	 * 
 	 * @return bool
 	 */
-	'permissions' => function () {
-		if(env('APP_ENV') == 'local')
-            return true;
-
-        return false;
-	},
+	'permissions' => env('APP_ENV') == 'local',
 
 );


### PR DESCRIPTION
Laravel do not fully support closure in config.

Using it in config cause application to break after running `config:cache`

`PHP Fatal error:  Call to undefined method Closure::__set_state() `

Ref: https://stackoverflow.com/questions/31154313/laravel-5-on-php-artisan-configclear-generated-closure-set-state-error

Ref: https://github.com/laravel/framework/issues/9625